### PR TITLE
Move queries out into files

### DIFF
--- a/SQL/files_table_fxn.sql
+++ b/SQL/files_table_fxn.sql
@@ -1,0 +1,9 @@
+-- Create table from S3 using FILES() table function
+CREATE TABLE DocsQA.user_behavior_inferred
+AS SELECT * FROM FILES (
+	"path" = "s3://starrocks-examples/user_behavior_ten_million_rows.parquet",
+	"format" = "parquet",
+	"aws.s3.region" = "us-east-1",
+	"aws.s3.access_key" = "AAAAAAAAAAAAAAAAAAAA",
+	"aws.s3.secret_key" = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+);

--- a/docs_test.go
+++ b/docs_test.go
@@ -6,7 +6,7 @@ import (
 	"database/sql"
 	"strings"
 	"os"
-	//"fmt"
+	"fmt"
 	//"time"
 	"github.com/go-sql-driver/mysql"
 )
@@ -57,18 +57,15 @@ var _ = Describe("Docs", func() {
 
 		It("should be able to run SQL commands", func() {
 			By("creating and populating a table")
-			SQL := `
-CREATE TABLE DocsQA.user_behavior_inferred AS
-SELECT * FROM FILES (
-	"path" = "s3://starrocks-examples/user_behavior_ten_million_rows.parquet",
-	"format" = "parquet",
-	"aws.s3.region" = "us-east-1",
-	"aws.s3.access_key" = "AAAAAAAAAAAAAAAAAAAA",
-	"aws.s3.secret_key" = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
-`
+			b, err := os.ReadFile("SQL/files_table_fxn.sql")
+			if err != nil {
+				fmt.Print(err)
+			}
+			SQL := string(b)
 			re := strings.NewReplacer( "AAAAAAAAAAAAAAAAAAAA", AWS_S3_ACCESS_KEY, "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", AWS_S3_SECRET_KEY)
+
 			SQLWithKey := re.Replace(SQL)
-			_, err := db.Exec(SQLWithKey)
+			_, err = db.Exec(SQLWithKey)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
The end goals are:

1. Test the content that goes into the docs
2. Single source the content: use the same exact files for the tests and the docs

This PR moves the SQL for creating a table using the FILES() table function out of the golang test code and into a separate file. The next step is to be able to include that file into the Markdown for the docs at doc build time.